### PR TITLE
Tax utxo verification

### DIFF
--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -28,6 +28,9 @@ const (
 	// tfModified indicates that a txout has been modified since it was
 	// loaded.
 	tfModified
+
+	// tfExpired indicates that a txout has been expired
+	tfExpired
 )
 
 // UtxoEntry houses details about an individual transaction output in a utxo
@@ -73,6 +76,26 @@ func (entry *UtxoEntry) BlockHeight() int32 {
 // current state of the unspent transaction output view it was obtained from.
 func (entry *UtxoEntry) IsSpent() bool {
 	return entry.packedFlags&tfSpent == tfSpent
+}
+
+// CheckExpired returns if utxo has expired or not by giving current height.
+// Active utxo means that it's existed in the active blockchain.
+// Expired utxo means that it's not existed in the active blockchain.
+// Active blockchain keeps the latest 368208 blocks.
+// 368208 = (7y x 365d x 24h + 2d x 24h) x 6
+func (entry *UtxoEntry) CheckExpired(txHeight int32) bool {
+	return txHeight-entry.blockHeight > 368208
+}
+
+// IsExpired returns if utxo has expired from the packedFlags information.
+func (entry *UtxoEntry) IsExpired() bool {
+	return entry.packedFlags&tfExpired == tfExpired
+}
+
+// Expired marks the output as expired
+func (entry *UtxoEntry) Expired() {
+	// Mark the output as expired
+	entry.packedFlags |= tfExpired
 }
 
 // Spend marks the output as spent.  Spending an output that is already spent

--- a/blockchain/utxoviewpoint_test.go
+++ b/blockchain/utxoviewpoint_test.go
@@ -1,0 +1,47 @@
+package blockchain
+
+import "testing"
+
+func TestCheckExpired(t *testing.T) {
+	utxoEntry := &UtxoEntry{
+		amount:      1000000,
+		blockHeight: 100001,
+	}
+
+	if utxoEntry.CheckExpired(200000) {
+		t.Error("Entry should not expired")
+	}
+}
+
+func TestIsExpired(t *testing.T) {
+	utxoEntryExpired := &UtxoEntry{
+		amount:      1000000,
+		blockHeight: 10000,
+		packedFlags: tfExpired,
+	}
+	if !utxoEntryExpired.IsExpired() {
+		t.Error("Entry should expired")
+	}
+
+	utxoEntryActive := &UtxoEntry{
+		amount:      1000000,
+		blockHeight: 10000,
+	}
+	if utxoEntryActive.IsExpired() {
+		t.Error("Entry should not expired")
+	}
+}
+
+func TestExpired(t *testing.T) {
+	utxoEntryActive := &UtxoEntry{
+		amount:      1000000,
+		blockHeight: 10000,
+	}
+	if utxoEntryActive.IsExpired() {
+		t.Error("Entry should not expired")
+	}
+	utxoEntryActive.Expired()
+	if !utxoEntryActive.IsExpired() {
+		t.Error("Entry should expired after set tfExpired flag")
+	}
+}

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -114,6 +114,22 @@ func IsCoinBase(tx *btcutil.Tx) bool {
 	return IsCoinBaseTx(tx.MsgTx())
 }
 
+// IsTaxTx checks if a transaction is a taxation transaction or not.
+// A Taxation transaction has multiple expired UTXOs as inputs.
+func IsTaxTx(msgTx *wire.MsgTx) bool {
+	// 0x00: regular non-witness tx
+	// 0x01: regular witness tx
+	// 0x11: tax witness tx
+	return msgTx.Type == 0x11
+}
+
+// IsTaxTransaction checks if a transaction is a taxation transaction or not.
+// A Taxation transaction has multiple expired UTXOs as inputs.
+// This function serves higher level of blockchain.
+func IsTaxTransaction(tx *btcutil.Tx) bool {
+	return IsTaxTx(tx.MsgTx())
+}
+
 // SequenceLockActive determines if a transaction's sequence locks have been
 // met, meaning that all the inputs of a given transaction have reached a
 // height or time sufficient for their relative lock-time maturity.

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -219,6 +219,19 @@ type Params struct {
 	// BIP44 coin type used in the hierarchical deterministic path for
 	// address generation.
 	HDCoinType uint32
+
+	// Valid blockchain length
+	ValidChainLength uint32
+
+	// obtc hardfork start from this height
+	TaxationBeginHeight int32
+
+	// Taxation params
+	TaxRate                    uint16
+	TaxTxUrgentWeight          uint16
+	TaxTxCommonWeight          uint16
+	DustSatoshiAmount          uint16
+	UrgentExpiredUtxoThreshold uint16
 }
 
 // MainNetParams defines the network parameters for the main Bitcoin network.
@@ -251,6 +264,12 @@ var MainNetParams = Params{
 	ReduceMinDifficulty:      false,
 	MinDiffReductionTime:     0,
 	GenerateSupported:        false,
+	ValidChainLength:         368208, // = (7y x 365d x 24h + 2d x 24h) x 6
+	TaxationBeginHeight:      568500, // approx 2019-03-24
+	TaxTxCommonWeight:        20,     // 20% by default
+	TaxTxUrgentWeight:        50,     // 50% by default
+	TaxRate:                  30,     // 30% by default
+	DustSatoshiAmount:        54600,  // 10x dust definition
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: []Checkpoint{
@@ -331,21 +350,28 @@ var RegressionNetParams = Params{
 	DNSSeeds:    []DNSSeed{},
 
 	// Chain parameters
-	GenesisBlock:             &regTestGenesisBlock,
-	GenesisHash:              &regTestGenesisHash,
-	PowLimit:                 regressionPowLimit,
-	PowLimitBits:             0x207fffff,
-	CoinbaseMaturity:         100,
-	BIP0034Height:            100000000, // Not active - Permit ver 1 blocks
-	BIP0065Height:            1351,      // Used by regression tests
-	BIP0066Height:            1251,      // Used by regression tests
-	SubsidyReductionInterval: 150,
-	TargetTimespan:           time.Hour * 24 * 14, // 14 days
-	TargetTimePerBlock:       time.Minute * 10,    // 10 minutes
-	RetargetAdjustmentFactor: 4,                   // 25% less, 400% more
-	ReduceMinDifficulty:      true,
-	MinDiffReductionTime:     time.Minute * 20, // TargetTimePerBlock * 2
-	GenerateSupported:        true,
+	GenesisBlock:               &regTestGenesisBlock,
+	GenesisHash:                &regTestGenesisHash,
+	PowLimit:                   regressionPowLimit,
+	PowLimitBits:               0x207fffff,
+	CoinbaseMaturity:           100,
+	BIP0034Height:              100000000, // Not active - Permit ver 1 blocks
+	BIP0065Height:              1351,      // Used by regression tests
+	BIP0066Height:              1251,      // Used by regression tests
+	SubsidyReductionInterval:   150,
+	TargetTimespan:             time.Hour * 24 * 14, // 14 days
+	TargetTimePerBlock:         time.Minute * 10,    // 10 minutes
+	RetargetAdjustmentFactor:   4,                   // 25% less, 400% more
+	ReduceMinDifficulty:        true,
+	MinDiffReductionTime:       time.Minute * 20, // TargetTimePerBlock * 2
+	GenerateSupported:          true,
+	ValidChainLength:           368208, // = (7y x 365d x 24h + 2d x 24h) x 6
+	TaxationBeginHeight:        568500, // approx 2019-03-24, This value may be changed for regression test
+	TaxTxCommonWeight:          20,     // 20% by default
+	TaxTxUrgentWeight:          50,     // 50% by default
+	TaxRate:                    30,     // 30% by default
+	DustSatoshiAmount:          54600,  // 10x dust definition
+	UrgentExpiredUtxoThreshold: 100,    // in block length
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: nil,
@@ -410,21 +436,28 @@ var TestNet3Params = Params{
 	},
 
 	// Chain parameters
-	GenesisBlock:             &testNet3GenesisBlock,
-	GenesisHash:              &testNet3GenesisHash,
-	PowLimit:                 testNet3PowLimit,
-	PowLimitBits:             0x1d00ffff,
-	BIP0034Height:            21111,  // 0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8
-	BIP0065Height:            581885, // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
-	BIP0066Height:            330776, // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
-	CoinbaseMaturity:         100,
-	SubsidyReductionInterval: 210000,
-	TargetTimespan:           time.Hour * 24 * 14, // 14 days
-	TargetTimePerBlock:       time.Minute * 10,    // 10 minutes
-	RetargetAdjustmentFactor: 4,                   // 25% less, 400% more
-	ReduceMinDifficulty:      true,
-	MinDiffReductionTime:     time.Minute * 20, // TargetTimePerBlock * 2
-	GenerateSupported:        false,
+	GenesisBlock:               &testNet3GenesisBlock,
+	GenesisHash:                &testNet3GenesisHash,
+	PowLimit:                   testNet3PowLimit,
+	PowLimitBits:               0x1d00ffff,
+	BIP0034Height:              21111,  // 0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8
+	BIP0065Height:              581885, // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
+	BIP0066Height:              330776, // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
+	CoinbaseMaturity:           100,
+	SubsidyReductionInterval:   210000,
+	TargetTimespan:             time.Hour * 24 * 14, // 14 days
+	TargetTimePerBlock:         time.Minute * 10,    // 10 minutes
+	RetargetAdjustmentFactor:   4,                   // 25% less, 400% more
+	ReduceMinDifficulty:        true,
+	MinDiffReductionTime:       time.Minute * 20, // TargetTimePerBlock * 2
+	GenerateSupported:          false,
+	ValidChainLength:           368208, // = (7y x 365d x 24h + 2d x 24h) x 6
+	TaxationBeginHeight:        568500, // approx 2019-03-24
+	TaxTxCommonWeight:          20,     // 20% by default
+	TaxTxUrgentWeight:          50,     // 50% by default
+	TaxRate:                    30,     // 30% by default
+	DustSatoshiAmount:          54600,  // 10x dust definition
+	UrgentExpiredUtxoThreshold: 100,    // in block length
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: []Checkpoint{
@@ -502,21 +535,28 @@ var SimNetParams = Params{
 	DNSSeeds:    []DNSSeed{}, // NOTE: There must NOT be any seeds.
 
 	// Chain parameters
-	GenesisBlock:             &simNetGenesisBlock,
-	GenesisHash:              &simNetGenesisHash,
-	PowLimit:                 simNetPowLimit,
-	PowLimitBits:             0x207fffff,
-	BIP0034Height:            0, // Always active on simnet
-	BIP0065Height:            0, // Always active on simnet
-	BIP0066Height:            0, // Always active on simnet
-	CoinbaseMaturity:         100,
-	SubsidyReductionInterval: 210000,
-	TargetTimespan:           time.Hour * 24 * 14, // 14 days
-	TargetTimePerBlock:       time.Minute * 10,    // 10 minutes
-	RetargetAdjustmentFactor: 4,                   // 25% less, 400% more
-	ReduceMinDifficulty:      true,
-	MinDiffReductionTime:     time.Minute * 20, // TargetTimePerBlock * 2
-	GenerateSupported:        true,
+	GenesisBlock:               &simNetGenesisBlock,
+	GenesisHash:                &simNetGenesisHash,
+	PowLimit:                   simNetPowLimit,
+	PowLimitBits:               0x207fffff,
+	BIP0034Height:              0, // Always active on simnet
+	BIP0065Height:              0, // Always active on simnet
+	BIP0066Height:              0, // Always active on simnet
+	CoinbaseMaturity:           100,
+	SubsidyReductionInterval:   210000,
+	TargetTimespan:             time.Hour * 24 * 14, // 14 days
+	TargetTimePerBlock:         time.Minute * 10,    // 10 minutes
+	RetargetAdjustmentFactor:   4,                   // 25% less, 400% more
+	ReduceMinDifficulty:        true,
+	MinDiffReductionTime:       time.Minute * 20, // TargetTimePerBlock * 2
+	GenerateSupported:          true,
+	ValidChainLength:           368208, // = (7y x 365d x 24h + 2d x 24h) x 6
+	TaxationBeginHeight:        568500, // approx 2019-03-24, This value may be changed for regression test
+	TaxTxCommonWeight:          20,     // 20% by default
+	TaxTxUrgentWeight:          50,     // 50% by default
+	TaxRate:                    30,     // 30% by default
+	DustSatoshiAmount:          54600,  // 10x dust definition
+	UrgentExpiredUtxoThreshold: 100,    // in block length
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: nil,

--- a/wire/msgreject.go
+++ b/wire/msgreject.go
@@ -25,6 +25,7 @@ const (
 	RejectDust            RejectCode = 0x41
 	RejectInsufficientFee RejectCode = 0x42
 	RejectCheckpoint      RejectCode = 0x43
+	RejectExpiredUtxo     RejectCode = 0x50
 )
 
 // Map of reject codes back strings for pretty printing.
@@ -37,6 +38,7 @@ var rejectCodeStrings = map[RejectCode]string{
 	RejectDust:            "REJECT_DUST",
 	RejectInsufficientFee: "REJECT_INSUFFICIENTFEE",
 	RejectCheckpoint:      "REJECT_CHECKPOINT",
+	RejectExpiredUtxo:     "REJECT_EXPIRED_UTXO",
 }
 
 // String returns the RejectCode in human-readable form.

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -775,6 +775,11 @@ func (msg *MsgTx) HasWitness() bool {
 	return false
 }
 
+// HasTax returns if tx is tax tx
+func (msg *MsgTx) HasTax() bool {
+	return msg.Type == 0x11
+}
+
 // Serialize encodes the transaction to w using a format that suitable for
 // long-term storage such as a database while respecting the Version field in
 // the transaction.  This function differs from BtcEncode in that BtcEncode


### PR DESCRIPTION
* Distinguish if a tx is a tax or regular tx
* Distinguish if utxo is expired or active
* Mempool can only accept regular tx. Tax tx should also be rejected since it will generated by the miner.
* Add Constants for eko:
```
 	ValidChainLength:         368208, // = (7y x 365d x 24h + 2d x 24h) x 6
 	TaxationBeginHeight:      568500, // approx 2019-03-24
 	TaxTxCommonWeight:        20,     // 20% by default
 	TaxTxUrgentWeight:        50,     // 50% by default
 	TaxRate:                  30,     // 30% by default
 	DustSatoshiAmount:        54600,  // 10x dust definition
```